### PR TITLE
chore: installer links

### DIFF
--- a/src/routes/Home/Wrapper.ts
+++ b/src/routes/Home/Wrapper.ts
@@ -50,8 +50,10 @@ export const HomeWrapper = styled.div`
         > div {
           margin: 0 2rem;
 
-          > img {
-            width: 15rem;
+          > a {
+            > img {
+              width: 15rem;
+            }
           }
         }
       }

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -18,10 +18,20 @@ export const Home = () => (
 
         <div className="download">
           <div>
-            <img src="/png/DownloadWindows.png" />
+            <a
+              href="https://github.com/polkadot-live/polkadot-live-app/releases/download/v0.1.0-alpha/Polkadot.Live-0.1.0-alpha-arm64.dmg"
+              download
+            >
+              <img src="/png/DownloadMac.png" />
+            </a>
           </div>
           <div>
-            <img src="/png/DownloadMac.png" />
+            <a
+              href="https://github.com/polkadot-live/polkadot-live-app/releases/download/v0.1.0-alpha/Polkadot.Live-0.1.0-alpha.Setup.exe"
+              download
+            >
+              <img src="/png/DownloadWindows.png" />
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Enable the macOS and Windows buttons to download the latest installers for the Polkadot Live application. 